### PR TITLE
Change the help string of -x

### DIFF
--- a/main.c
+++ b/main.c
@@ -21,7 +21,7 @@ void dispInfo(char *exename)
 	printf("%s -u ipaddr file path opt\t\t- Upload file, opt 0: no header add, 1: add ascii header\r\n", exename);
 	printf("%s -d ipaddr file path opt\t\t- Download file, opt 0: leave header, 1: remove header\r\n", exename);
 	printf("%s -f ipaddr file slot name\t\t- Upload rom\r\n", exename);
-	printf("%s -x ipaddr path+file\t\t- Execute remote file\r\n", exename);
+	printf("%s -x ipaddr path+file\t\t- Execute file on CPC\r\n", exename);
 	printf("%s -s ipaddr\t\t\t\t- Reset CPC\r\n", exename);
 	printf("%s -r ipaddr\t\t\t\t- Reboot M4\r\n", exename);
 	


### PR DESCRIPTION
This is a suggestion to modify the help string of the -x option.

Why ?
During hours I badly understood the term "remote". I thought that remote was my PC and not the CPC.
So each time I tried to execute a file from my PC to my CPC it failed as this file was never uploaded to the CPC.

If other people translate like me, this patch has an interest.


Otherwise, forget it.