### PR TITLE
Added define for redirecting strnicmp to use strncasecmp instead.

### DIFF
--- a/http.c
+++ b/http.c
@@ -12,6 +12,10 @@
 
 #define BOUNDARY_ID		"-------------123123123"
 
+#ifndef __WIN32__
+       #define strnicmp strncasecmp
+#endif
+
 int httpConnect(char *host)
 {
 	SOCKET sd;

--- a/main.c
+++ b/main.c
@@ -16,6 +16,7 @@
        #include <sys/types.h>
        #include <sys/stat.h>
        #include <unistd.h>
+       #define strnicmp strncasecmp
 #endif
 
 // mres = m4 reboot

--- a/parse.c
+++ b/parse.c
@@ -6,8 +6,9 @@
 #include "string.h"
 
 
-
-
+#ifndef __WIN32__
+       #define strnicmp strncasecmp
+#endif
 
 
 #ifdef __unix__  


### PR DESCRIPTION
This allows the program to be compiled and run seamlessly on MacOS and Linux.

Tested both and the program was able to reset the CPC, download and upload files.